### PR TITLE
Update Webarena's requirements to support Python 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# About this repository
+
+Public repository forked from morrissharp/webarena:main(3de52d3c46ce8280f9473ca5bd45077ff1737527). Currently, the repo is not in use but serves as a backup for morrissharp/webarena (which is used as a submodule at Project24_LI).
+
 # WebArena: A Realistic Web Environment for Building Autonomous Agents
 <p align="center">
     <img src="media/logo.png" alt="Logo" width="80px">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gymnasium
-playwright==1.32.1
+playwright>=1.51.0
 Pillow
 evaluate
 openai
@@ -10,4 +10,4 @@ beartype==0.12.0
 flask
 nltk
 text-generation
-transformers==4.33.2
+transformers==4.57.0


### PR DESCRIPTION
This PR update Webarena's requirements to support Python 12